### PR TITLE
Update 01-iris-classification-with-knn.ipynb

### DIFF
--- a/01-iris-classification-with-knn.ipynb
+++ b/01-iris-classification-with-knn.ipynb
@@ -491,7 +491,7 @@
     }
    ],
    "source": [
-    "print(\"Test set score: {:.2f}\".format(knn.score(X_test, y_test)))"
+    "print(\"Test set score: {:.2f}\".format(knn.score(y_pred, y_test)))"
    ]
   },
   {


### PR DESCRIPTION
a little bug, X_train must replace with y_pred, because we want to find score of predictions