### PR TITLE
warning reason + fix

### DIFF
--- a/solutions/07B_knn_vs_linreg.py
+++ b/solutions/07B_knn_vs_linreg.py
@@ -2,26 +2,28 @@ from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LinearRegression
 from sklearn.neighbors import KNeighborsRegressor
+import numpy as np
+import pandas as pd
+import matplotlib as plt
 
 
-boston = load_boston()
-X = boston.data
-y = boston.target
+dataurl = "http://lib.stat.cmu.edu/datasets/boston"
+raw_df = pd.read_csv(dataurl, sep="\s+", skiprows=22, header=None)
+data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])  # why odd rows have [:2] columns  
+target = raw_df.values[1::2, 2]
 
-print('X.shape:', X.shape)
-X_train, X_test, y_train, y_test = train_test_split(X, y,
-                                                    test_size=0.25,
-                                                    random_state=42)
+print('data.shape:', data.shape)
+
+x_train, x_test, y_train, y_test = train_test_split(data, target, test_size=0.25, random_state=42)
 
 linreg = LinearRegression()
-knnreg = KNeighborsRegressor(n_neighbors=1)
+knnreg = KNeighborsRegressor(n_neighbors=3)
 
-linreg.fit(X_train, y_train)
-print('Linear Regression Train/Test: %.3f/%.3f' %
-      (linreg.score(X_train, y_train),
-       linreg.score(X_test, y_test)))
+linreg.fit(x_train, ytrain)
+print('Linear Regression Train/Test: %.3f/%.3f' % (linreg.score(x_train, y_train), linreg.score(x_test, y_test)))
 
-knnreg.fit(X_train, y_train)
-print('KNeighborsRegressor Train/Test: %.3f/%.3f' %
-      (knnreg.score(X_train, y_train),
-       knnreg.score(X_test, y_test)))
+knnreg.fit(x_train, y_train)
+print('KNeighborsRegressor Train/Test: %.3f/%.3f' % (knnreg.score(x_train, y_train), knnreg.score(x_test, y_test)))
+
+plt.plot(xtest, ytest, 'o', label="data")
+plt.legend(loc='best');


### PR DESCRIPTION
<div class="alert alert-warning">
<b>Warning</b>: The Boston housing prices dataset has an ethical problem: as investigated in <a href="https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html#rec2f484fdebe-1">[1]</a>, the authors of this dataset engineered a non-invertible variable “B” assuming that racial self-segregation had a positive impact on house prices <a href="https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html#rec2f484fdebe-2">[2]</a>. 

In this special case, you can fetch the dataset from the original source to ignore warnings:
</div>